### PR TITLE
Include contrib in source package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat
 recursive-include dbsake templates/*
+recursive-include contrib *


### PR DESCRIPTION
With contrib inside, you can build a rpm package as easy as:

$ python setup.py sdist
$ rpmbuild -ta dist/dbsake-*.tar.gz