### PR TITLE
Remove unicode_literals imports from dbsake.cli

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 =======
 
+2.1.1 (unreleased)
+------------------
+
+Bugs fixed:
+
+   * Remove unicode_literals usage in cli to avoid noisy warnings from click
+     (Issue #96)
+
 2.1.0 (2015-01-28)
 ------------------
 

--- a/dbsake/cli/__init__.py
+++ b/dbsake/cli/__init__.py
@@ -4,8 +4,6 @@ dbsake.cli
 
 Main dbsake cli entrypoint
 """
-from __future__ import unicode_literals
-
 import logging
 import sys
 

--- a/dbsake/cli/cmd/frm.py
+++ b/dbsake/cli/cmd/frm.py
@@ -4,8 +4,6 @@ dbsake.cmd.frmdump
 
 Dump schema from MySQL .frm files
 """
-from __future__ import unicode_literals
-
 import sys
 
 import click

--- a/dbsake/cli/cmd/fs.py
+++ b/dbsake/cli/cmd/fs.py
@@ -5,8 +5,6 @@ dbsake.cmd.fs
 Commands for interacting with the local filesystem
 
 """
-from __future__ import unicode_literals
-
 import sys
 
 import click

--- a/dbsake/cli/cmd/mycnf.py
+++ b/dbsake/cli/cmd/mycnf.py
@@ -4,8 +4,6 @@ dbsake.cli.cmd.mycnf
 
 MySQL option file utilitie
 """
-from __future__ import unicode_literals
-
 import sys
 
 import click

--- a/dbsake/cli/cmd/sandbox.py
+++ b/dbsake/cli/cmd/sandbox.py
@@ -4,8 +4,6 @@ dbsake.cmd.sandbox
 
 Command interface to create isolated MySQL "sandbox" instances
 """
-from __future__ import unicode_literals
-
 import os
 import sys
 

--- a/dbsake/cli/cmd/sieve.py
+++ b/dbsake/cli/cmd/sieve.py
@@ -4,8 +4,6 @@ dbsake.cmd.sieve
 
 Advanced filtering of mysqldump backup files
 """
-from __future__ import unicode_literals
-
 import errno
 import signal
 import sys

--- a/dbsake/cli/cmd/unpack.py
+++ b/dbsake/cli/cmd/unpack.py
@@ -6,7 +6,6 @@ Archive unpack cli frontend
 
 """
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import sys
 

--- a/tests/frmdump/test_frm.py
+++ b/tests/frmdump/test_frm.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from __future__ import print_function
 
 import codecs
@@ -45,14 +44,13 @@ def test_frm_decode(frm_path, expected_sql):
 
 
 def test_frm_tablename():
-    sample = 'Настройки'
+    sample = u'Настройки'
     expected_encoding = b'@T0@g0@x0@y0@w0@u0@p0@q0@o0'
 
     result = tablename.encode(sample)
 
     assert result == expected_encoding
 
-    print("result => %r" % (result, ))
     orig = tablename.decode(result)
 
     assert orig == sample

--- a/tests/test_dbsake.py
+++ b/tests/test_dbsake.py
@@ -1,8 +1,6 @@
 """
 Test dbsake cli
 """
-from __future__ import unicode_literals
-
 from click.testing import CliRunner
 
 import dbsake

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,8 +1,6 @@
 """
 Test dbsake sandbox
 """
-from __future__ import unicode_literals
-
 from click.testing import CliRunner
 
 from dbsake.cli.cmd import fs as fs_cli

--- a/tests/test_pycompat.py
+++ b/tests/test_pycompat.py
@@ -1,8 +1,6 @@
 """
 Test dbsake.pycompat
 """
-from __future__ import unicode_literals
-
 import errno
 import os
 import shutil

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,8 +1,6 @@
 """
 Test dbsake sandbox
 """
-from __future__ import unicode_literals
-
 import os
 import tarfile
 

--- a/tests/test_sieve.py
+++ b/tests/test_sieve.py
@@ -1,8 +1,6 @@
 """
 Test dbsake cli
 """
-from __future__ import unicode_literals
-
 import os
 
 from click.testing import CliRunner

--- a/tests/test_upgrademycnf.py
+++ b/tests/test_upgrademycnf.py
@@ -1,8 +1,6 @@
 """
 Test dbsake sandbox
 """
-from __future__ import unicode_literals
-
 import os
 
 from click.testing import CliRunner

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,8 +2,6 @@
 Test dbsake.util.compression
 
 """
-from __future__ import unicode_literals
-
 from dbsake.util import compression
 
 


### PR DESCRIPTION
Avoids noisy warnings from click.  There are still many instances where
unicode_literals are still imported through the api and these should be
deprecated over time.

Fixes #96