### PR TITLE
Update tox.ini

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ universal = 1
 # we don't do any stylistic checks
 # since it's effectively stdlib
 exclude = dbsake/util/enum.py
-
-[pytest]
-addopts = --cov-report term-missing

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py26, py27, py33, py34, py35, py36, pypy
 skip-missing-interpreters=true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,6 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 whitelist_externals=make
+
+[pytest]
+addopts = --cov-report term-missing


### PR DESCRIPTION
- Adds python 3.5, 3.6 to tox.ini's envlist
- Move [pytest] from setup.cfg to tox.ini to avoid warning pytest 3.0+