### PR TITLE
add frmdump --recursive option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
 2.1.1 (unreleased)
 ------------------
 
+New features
+
+   * Add frmdump --recursive option to dump all \*.frm files found in the target directory
+     (issue #60)
+
 Bugs fixed:
 
    * sandbox generated sandbox.sh script would previously wait for the

--- a/dbsake/cli/cmd/frm.py
+++ b/dbsake/cli/cmd/frm.py
@@ -4,6 +4,7 @@ dbsake.cmd.frmdump
 
 Dump schema from MySQL .frm files
 """
+import os
 import sys
 
 import click
@@ -11,37 +12,64 @@ import click
 from dbsake.cli import dbsake
 
 
+def parse_and_print(frm_path, type_codes, replace):
+    """Parse the specified .frm path and output
+
+    On failure, emit the failed path on stderr and return
+    1 for the failure count.
+
+    On success, emit the frm on stdout and return 0 for the failure count
+    """
+    from dbsake.core.mysql import frm
+
+    try:
+        table = frm.parse(frm_path)
+    except frm.Error as exc:
+        click.echo("Failed to parse %s: %s" % (frm_path, exc), file=sys.stderr)
+        return 1
+
+    if table.type == 'VIEW':
+        click.echo(table.format(replace))
+    else:
+        click.echo(table.format(type_codes))
+    return 0
+
+
 @dbsake.command('frmdump', options_metavar="[options]")
 @click.option('-t', '--type-codes',
               default=False,
               is_flag=True,
               help="Show mysql type codes in comments on each column")
+@click.option('-r', '--recursive',
+              is_flag=True,
+              default=False,
+              help="Recursively search directories for .frm files.")
 @click.option('-R', '--replace',
               default=False,
               is_flag=True,
               help="Output views with CREATE OR REPLACE")
 @click.argument('path',
-                type=click.Path(dir_okay=False, resolve_path=True),
+                type=click.Path(dir_okay=True, resolve_path=True),
                 metavar="[path...]",
                 nargs=-1)
-def frmdump(path, type_codes, replace):
+@click.pass_context
+def frmdump(ctx, path, recursive, type_codes, replace):
     """Dump schema from MySQL frm files."""
-    from dbsake.core.mysql import frm
+    def _walk_directory(path):
+        for dirpath, dirnames, filenames in os.walk(path):
+            for name in filenames:
+                yield os.path.join(dirpath, name)
 
     failures = 0
-
     for name in path:
-        try:
-            table = frm.parse(name)
-        except frm.Error as exc:
-            click.echo("Failed to parse %s: %s" % (name, exc), file=sys.stderr)
-            failures += 1
-            continue
+        if recursive and os.path.isdir(name):
+            for subpath in _walk_directory(name):
+                if not subpath.endswith('.frm'):
+                    continue
+                failures += parse_and_print(subpath, type_codes, replace)
         else:
-            if table.type == 'VIEW':
-                click.echo(table.format(replace))
-            else:
-                click.echo(table.format(type_codes))
+            failures += parse_and_print(name, type_codes, replace)
+
     if failures > 0:
         click.echo("Failed to parse %d paths" % failures, file=sys.stderr)
         sys.exit(1)

--- a/dbsake/core/mysql/frm/keys.py
+++ b/dbsake/core/mysql/frm/keys.py
@@ -71,8 +71,8 @@ class Key(collections.namedtuple('Key',
         if self.index_type in ('FULLTEXT', 'SPATIAL'):
             # FULLTEXT / SPATIAL may never have an index prefix
             return value
-        elif (part.column.type_code.name in self.maybe_prefix_types
-                and part.length != part.column.length) or \
+        elif (part.column.type_code.name in self.maybe_prefix_types and
+                part.length != part.column.length) or \
              (part.column.type_code.name in self.always_prefix_types):
                 prefix_length = part.length // part.column.charset.maxlen
                 value += '({0})'.format(prefix_length)

--- a/dbsake/pycompat.py
+++ b/dbsake/pycompat.py
@@ -183,8 +183,8 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         Additionally check that `file` is not a directory, as on Windows
         directories pass the os.access check.
         """
-        return (os.path.exists(filename) and os.access(filename, mode)
-                and not os.path.isdir(filename))
+        return (os.path.exists(filename) and os.access(filename, mode) and
+                not os.path.isdir(filename))
 
     # If we're given a path with a directory part, look it up directly rather
     # than referring to PATH directories. This includes checking relative to

--- a/tests/frmdump/test_frm.py
+++ b/tests/frmdump/test_frm.py
@@ -43,6 +43,17 @@ def test_frm_decode(frm_path, expected_sql):
     assert derived_sql == expected_sql
 
 
+def test_frmdump_recursive():
+    runner = CliRunner()
+    frm_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    expected_frm_count = len([name for name in os.listdir(frm_path)
+                              if name.endswith('.frm')])
+    result = runner.invoke(frmdump, ['--recursive', frm_path], obj={})
+    computed_frm_count = result.output.count('\nCREATE ')
+    assert result.exit_code == 0
+    assert computed_frm_count == expected_frm_count
+
+
 def test_frm_tablename():
     sample = u'Настройки'
     expected_encoding = b'@T0@g0@x0@y0@w0@u0@p0@q0@o0'


### PR DESCRIPTION
This option will allow a directory path to be specified and will
walk that directory looking for additional .frm files.  This
allows specifying the datadir to dump all .frm definitions rather
than the current behavior of having to specify every path as
an argument on the commandline.

Resolves issue #60