### PR TITLE
Set system_user based on getpass.getuser()

### DIFF
--- a/dbsake/core/mysql/sandbox/__init__.py
+++ b/dbsake/core/mysql/sandbox/__init__.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import getpass
 import logging
 import os
 import time
@@ -60,7 +61,7 @@ def create(**options):
     common.generate_defaults(sbopts,
                              mysql_user=sbopts.mysql_user,
                              password=sbopts.password,
-                             system_user=os.environ['USER'],
+                             system_user=getpass.getuser(),
                              distribution=dist,
                              basedir=dist.basedir,
                              datadir=sbopts.datadir,


### PR DESCRIPTION
sandbox previously just used environ['USER'], which is fragile and
breaks under local python-tox runs. This is a trivial update to
use getpass.getuser() instead which is somewhat more robust and
fixes sandbox tests that may fail under tox.