### PR TITLE
Modify sandbox.sh start logic

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ History
 
 Bugs fixed:
 
+   * sandbox generated sandbox.sh script would previously wait for the
+     mysqld socket to appear as part of the "start" action, which was
+     problematic for Galera based binaries.  sandbox.sh start now waits
+     for the pid-file to appear via the "sandbox.sh status" action.
+     (issue #88)
    * unpack command had a bug that failed on uncompressed input; similarly
      affected the sandbox command when unpacking uncompressed archives via
      the --data-source / -s option (issue #90)


### PR DESCRIPTION
Previously start waited for the mysqld socket file to appear as
the test for a successful service start.  Now start waits for the
pid-file to appear. This avoids a bug when starting a Galera enabled
mysqld, where mysqld may actually be started twice as part of the
recovery process, but startup fails after the first unix socket
appears.  Testing for pid-file is also a more standard practice
among mysql initscripts.

Resolves issue #88