### PR TITLE
Avoid ledir in my.sandbox.cnf

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,14 +13,21 @@ Bugs fixed:
      problematic for Galera based binaries.  sandbox.sh start now waits
      for the pid-file to appear via the "sandbox.sh status" action.
      (issue #88)
+
    * frmdump failed to decode tables specified with utf8mb4, binary or other
      less common encodings.  (issues #97, #102)
+
    * unpack command had a bug that failed on uncompressed input; similarly
      affected the sandbox command when unpacking uncompressed archives via
      the --data-source / -s option (issue #90)
+
    * upgrade-mycnf now handles paths with spaces (issue #94)
+
    * Remove unicode_literals usage in cli to avoid noisy warnings from click
      (Issue #96)
+
+   * starting a sandbox failed on recent versions of MySQL due to the mysqld_safe
+     ledir option now being prohibited in config files. (issue #103)
 
 2.1.0 (2015-01-28)
 ------------------

--- a/dbsake/core/mysql/sandbox/templates/my.sandbox.cnf
+++ b/dbsake/core/mysql/sandbox/templates/my.sandbox.cnf
@@ -124,6 +124,5 @@ long-query-time                     = 2
 {% endif %}
 
 [mysqld_safe]
-ledir                               = {{distribution.libexecdir}}
 log-error                           = {{datadir}}/mysqld.log
 open-files-limit                    = {{open_files_limit|default(65535)}}

--- a/dbsake/core/mysql/sandbox/templates/sandbox.sh
+++ b/dbsake/core/mysql/sandbox/templates/sandbox.sh
@@ -46,7 +46,7 @@ sandbox_start() {
     fi
     echo -n "Starting sandbox: "
     # close stdin (0) and redirect stdout/stderr to /dev/null
-    mysqld_safe_args="--defaults-file=$defaults_file"
+    mysqld_safe_args="--defaults-file=$defaults_file --ledir='{{ distribution.libexecdir }}'"
     MY_BASEDIR_VERSION=${basedir} \
         nohup $mysqld_safe $mysqld_safe_args "$@" 0<&- &>/dev/null &
     local start_timeout=${START_TIMEOUT}

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -50,6 +50,40 @@ def test_sandbox_50():
         assert result.exit_code == 0
 
 
+# TODO: parameterize the test_sandbox_XX tests to avoid this boiler plate
+# TODO: split these tests into separate w/ & w/o datasource
+@pytest.mark.skipif(os.environ.get('TRAVIS', 'false') == 'true',
+                    reason="Skipping sandbox CDN tests on travis-ci")
+def test_sandbox_56():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        sbdir = os.path.abspath('test_sandbox')
+        result = runner.invoke(sandbox_cli,
+                               ['-d', sbdir, '-m', '5.6.35'],
+                               auto_envvar_prefix='DBSAKE', obj={})
+        assert result.exit_code == 0
+        result = runner.invoke(sandbox_cli,
+                               ['--force',
+                                '-d', sbdir,
+                                '-m', '5.6.35'],
+                               auto_envvar_prefix='DBSAKE', obj={})
+        assert result.exit_code == 0
+        tar = tarfile.open("backup.tar.gz", "w:gz")
+        cwd = os.getcwd()
+        os.chdir(os.path.join(sbdir, 'data'))
+        tar.add('.')
+        tar.close()
+        os.chdir(cwd)
+        result = runner.invoke(sandbox_cli,
+                               ['--force',
+                                '-d', sbdir,
+                                '-m', '5.6.35',
+                                '-s', 'backup.tar.gz',
+                                '-t', 'mysql.user'],
+                               auto_envvar_prefix='DBSAKE', obj={})
+        assert result.exit_code == 0
+
+
 '''
 def test_sandbox_51():
     runner = CliRunner()


### PR DESCRIPTION
As of MySQL 5.6.35,5.5.54,5.7.17 ledir is no longer allowed as
a [mysqld_safe] option in a config file.  This option may only
be provided as a command line argument.

Fixes #103