### PR TITLE
Fix dbsake sandbox.sh --ledir quoting

### DIFF
--- a/.travis-test-requirements.txt
+++ b/.travis-test-requirements.txt
@@ -1,2 +1,3 @@
 # travis specific requirements go here
 coveralls
+pytest-catchlog

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 =======
 
+2.1.2 (unreleased)
+------------------
+
+Bugs fixed:
+
+   * dbsake 2.1.1 sandbox command was broken due to incorrectly quoting the --ledir argument
+     when generating sandbox.sh (issue #120)
+
 2.1.1 (2017-02-07)
 ------------------
 

--- a/contrib/dbsake.spec
+++ b/contrib/dbsake.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 Name:           dbsake
-Version:        2.1.1
+Version:        2.1.2
 Release:        1%{?dist}
 Summary:        A DBA's (s)wiss-(a)rmy-(k)nif(e) for mysql
 Group:          Applications/Databases
@@ -59,6 +59,9 @@ chmod 0755 %{buildroot}%{_bindir}/dbsake
 %{_bindir}/dbsake
 
 %changelog
+* Wed Feb 14 2017 Andrew Garner <andrew.garner@rackspace.com> - 2.1.2-1
+- Updating for new release
+
 * Wed Feb 01 2017 Andrew Garner <andrew.garner@rackspace.com> - 2.1.1-1
 - Updating for new release
 

--- a/dbsake/__init__.py
+++ b/dbsake/__init__.py
@@ -4,4 +4,4 @@ dbsake
 
 """
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'

--- a/dbsake/cli/cmd/sandbox.py
+++ b/dbsake/cli/cmd/sandbox.py
@@ -4,6 +4,7 @@ dbsake.cmd.sandbox
 
 Command interface to create isolated MySQL "sandbox" instances
 """
+import logging
 import os
 import sys
 
@@ -118,5 +119,5 @@ def sandbox_cli(sandbox_directory,
                        innobackupex_options=innobackupex_options,
                        report_progress=report_progress)
     except sandbox.SandboxError as exc:
-        click.echo("%s" % exc, file=sys.stderr)
+        logging.error("%s", exc)
         sys.exit(os.EX_SOFTWARE)

--- a/dbsake/core/mysql/sandbox/__init__.py
+++ b/dbsake/core/mysql/sandbox/__init__.py
@@ -79,7 +79,7 @@ def create(**options):
                                                           'my.sandbox.cnf'))
 
     info("  Initializing database user")
-    common.initial_mysql_user(sbopts)
+    common.initialize_mysql_user(sbopts)
 
     info("Sandbox created in %.2f seconds", time.time() - start)
     info("")

--- a/dbsake/core/mysql/sandbox/common.py
+++ b/dbsake/core/mysql/sandbox/common.py
@@ -330,7 +330,7 @@ def bootstrap(options, distribution, additional_options=()):
     info("    * Bootstrapped sandbox in %.2f seconds", time.time() - start)
 
 
-def initial_mysql_user(options):
+def initialize_mysql_user(options):
     sbdir = options.basedir
     sbuser = options.mysql_user
     sbpass = options.password
@@ -349,12 +349,16 @@ def initial_mysql_user(options):
             start_cmd = "%s start --init-file=%s" % (sandbox_sh, fileobj.name)
             stop_cmd = "%s stop" % (sandbox_sh,)
             logging.info("    - Running: %s", start_cmd)
-            status = cmd.run(start_cmd, stdout=devnull, stderr=devnull)
-            if status != 0:
-                logging.error("Failed to initialize sandbox. "
+            start_status = cmd.run(start_cmd, stdout=devnull, stderr=devnull)
+            if start_status != 0:
+                logging.error("    !! Failed to initialize sandbox. "
                               "Check %s for details",
                               os.path.join(sbdir, "data", "mysqld.log"))
             logging.info("    - Running: %s", stop_cmd)
-            cmd.run(stop_cmd, stdout=devnull, stderr=devnull)
+            stop_status = cmd.run(stop_cmd, stdout=devnull, stderr=devnull)
+            status = start_status or stop_status
+
+    if status != 0:
+        raise SandboxError("Sandbox user initialization failed")
     logging.info("    * Initialized MySQL user in %.2f seconds",
                  time.time() - start)

--- a/dbsake/core/mysql/sandbox/templates/sandbox.sh
+++ b/dbsake/core/mysql/sandbox/templates/sandbox.sh
@@ -46,7 +46,7 @@ sandbox_start() {
     fi
     echo -n "Starting sandbox: "
     # close stdin (0) and redirect stdout/stderr to /dev/null
-    mysqld_safe_args="--defaults-file=$defaults_file --ledir='{{ distribution.libexecdir }}'"
+    mysqld_safe_args="--defaults-file=$defaults_file --ledir={{ distribution.libexecdir }}"
     MY_BASEDIR_VERSION=${basedir} \
         nohup $mysqld_safe $mysqld_safe_args "$@" 0<&- &>/dev/null &
     local start_timeout=${START_TIMEOUT}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ copyright = u'2014, Andrew Garner'
 # built documents.
 #
 # The short X.Y version.
-version = '2.1.1'
+version = '2.1.2'
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
- Change sandbox behavior to fail if user initialization fails
  so tests can catch sandbox misbehavior easily
- Remove incorrect quotes around --ledir argument in sandbox.sh
  template

Fixes #120