### PR TITLE
Make sandbox_status() more portable

### DIFF
--- a/dbsake/core/mysql/sandbox/templates/sandbox.sh
+++ b/dbsake/core/mysql/sandbox/templates/sandbox.sh
@@ -65,7 +65,8 @@ sandbox_start() {
 
 sandbox_status() {
     pidfile=$(_mysqld_option pid-file mysqld mysqld_safe)
-    if [[ -s "${pidfile}" && $(ps ho comm $(cat ${pidfile})) == mysqld ]]
+    if [[ -s "${pidfile}" && \
+          $(basename $(ps -p $(<${pidfile}) -o comm=)) == "mysqld" ]]
     then
         { pid=$(<"${pidfile}"); } 2>/dev/null
     fi


### PR DESCRIPTION
Previously sandbox.sh -> sandbox_status() was taught to check for stale
pid files and make sure any pid found actually mapped to a process named
"mysqld".  This pid processname check fails on OS X, at least and
probably any non-linux platform.

Fixes #126