### PR TITLE
Support mysql 5.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.1.3 (unreleased)
+------------------
+
+Bugs fixed
+
+  * sandbox now handles MySQL 5.7 instance bootstrapping (PR #128)
+
 2.1.2 (2017-02-15)
 ------------------
 


### PR DESCRIPTION
sandbox has been broken for some time with MySQL 5.7, due to
the removal of the mysql.user (Password) column as of 5.7.6.

This adds minimal changes to allow the sandbox bootstrapping
to work with 5.7.