### PR TITLE
Delay bootstrapping until sandbox.sh has been generated

### DIFF
--- a/dbsake/core/mysql/sandbox/__init__.py
+++ b/dbsake/core/mysql/sandbox/__init__.py
@@ -55,8 +55,10 @@ def create(**options):
     # And generating defaults cannot be done until we have an
     # innodb-log-file-size
     datasource.preload(sbopts)
+
     info("  Deploying MySQL distribution")
     dist = distribution.deploy(sbopts)
+
     info("  Generating my.sandbox.cnf")
     common.generate_defaults(sbopts,
                              mysql_user=sbopts.mysql_user,
@@ -69,14 +71,16 @@ def create(**options):
                              tmpdir=os.path.join(sbdir, 'tmp'),
                              mysql_version=dist.version,
                              port=dist.version.as_int())
-    info("  Bootstrapping sandbox instance")
-    common.bootstrap(sbopts, dist)
+
     info("  Creating sandbox.sh initscript")
     common.generate_initscript(sbdir,
                                distribution=dist,
                                datadir=sbopts.datadir,
                                defaults_file=os.path.join(sbdir,
                                                           'my.sandbox.cnf'))
+
+    info("  Bootstrapping sandbox instance")
+    common.bootstrap(sbopts, dist)
 
     info("  Initializing database user")
     common.initialize_mysql_user(sbopts)


### PR DESCRIPTION
This pushes the bootstrapping process until after sandbox.sh is
rendered.  This allows recovering from a failed bootstrap process
more easily. This might happen when testing against a newer version
of MySQL that the sandbox command doesn't support yet, or if the
particular datasource used is incompatible with the distribution of
MySQL chosen, among other possible issues.