### PR TITLE
change defaults for sieve --compress-command

### DIFF
--- a/dbsake/cli/cmd/sieve.py
+++ b/dbsake/cli/cmd/sieve.py
@@ -11,6 +11,7 @@ import sys
 import click
 
 from dbsake.cli import dbsake
+from dbsake.util import compression
 
 
 @dbsake.command('sieve', options_metavar='[options]')
@@ -31,7 +32,7 @@ from dbsake.cli import dbsake
               help="Specify input file to process instead of stdin")
 @click.option('-z', '--compress-command',
               metavar='<name>',
-              default='gzip -1',
+              default=compression.filetype_to_command('.gz'),
               help="Specify compression command when --format=directory")
 @click.option('-t', '--table',
               metavar='<glob>',

--- a/dbsake/util/compression.py
+++ b/dbsake/util/compression.py
@@ -226,10 +226,8 @@ def filetype_to_command(ext):
 
     for name in candidates:
         # resolve "canonical" binpath
-        cbin = pycompat.which(name)
-        if not cbin:
-            continue
-        return cbin + ' -dc'
+        if pycompat.which(name):
+            return name
 
     raise OSError("Unable to find compression method for extension '%s'" %
                   (ext,))
@@ -266,6 +264,8 @@ def decompressed(stream, report_progress=False, sizehint=None, filetype=None):
         stream = io.open(stream.fileno(), 'rb', closefd=False)
         filetype = detect_filetype(stream)
     command = filetype_to_command(filetype)
+    if command is not None:
+        command += ' -dc'
     if report_progress and (sizehint or is_seekable(stream)):
         streamsize = sizehint or os.fstat(stream.fileno()).st_size
         widget = progress_bar(streamsize)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 # test requirements go here
-coverage==3.7.1
+coverage
 pytest
 pytest-cov>=2.4.0,<2.6
 flake8<3.0


### PR DESCRIPTION
Use compression utilities to find a compression command for gzip files.  This will pick up "pigz" by default, if available in the environment.

Note: This changes the default behavior for sieve --format=directory from gzip -1 to "gzip".

Fixes #130